### PR TITLE
add support for url parameters

### DIFF
--- a/pyodide_http/_requests.py
+++ b/pyodide_http/_requests.py
@@ -17,6 +17,12 @@ class Session:
 
     @staticmethod
     def request(method, url, **kwargs):
+        if 'params' in kwargs:
+            from js import URLSearchParams
+            params = URLSearchParams.new()
+            for k, v in kwargs['params'].items():
+                params.append(k, v)
+            url += "?"+params.toString()
         request = Request(method, url)
         request.headers = kwargs.get('headers', {})
         if 'json' in kwargs:


### PR DESCRIPTION
this implements the params argument in requests. It just adds url parameters in ?param=value format.

I'm using pyodide-http in my project, and I needed this, would be nice to upstream it so we can get from pypi. 

I've also got some code for streaming http if you're in a web worker and cross origin isolated, I'll chuck that in as a PR next.