### PR TITLE
patched requests at lower level

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   # Build for pyodide 0.21.0
-  Pyodide_build:
+  Pyodide_test_and_build:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
@@ -22,9 +22,9 @@ jobs:
       with:
         version: 3.1.14
     - run: pip install pyodide-build==0.21.0
-    - run: pyodide build
+    - run: pyodide build    
     - uses: actions/upload-artifact@v3
       with:
         name: pyodide wheel
         path: dist
-
+    - run: bash ./setup_test_env.sh

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 .*
 !.github
+tests/pyodide
+build
+dist
+__pycache__
+*.egg-info/

--- a/pyodide_http/_core.py
+++ b/pyodide_http/_core.py
@@ -90,8 +90,6 @@ def send(request: Request, stream: bool = False) -> Response:
     # XMLHttpRequest https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
     if _IN_WORKER and request.timeout!=0:
         xhr.timeout=int(request.timeout*1000)
-    for name, value in request.headers.items():
-        xhr.setRequestHeader(name, value)
 
     if _IN_WORKER:
         xhr.responseType = "arraybuffer"
@@ -99,6 +97,9 @@ def send(request: Request, stream: bool = False) -> Response:
         xhr.overrideMimeType('text/plain; charset=ISO-8859-15')
 
     xhr.open(request.method, request.url, False)
+    for name, value in request.headers.items():
+        xhr.setRequestHeader(name, value)
+
     xhr.send(request.body)
 
     headers = dict(Parser().parsestr(xhr.getAllResponseHeaders()))

--- a/pyodide_http/_requests.py
+++ b/pyodide_http/_requests.py
@@ -1,6 +1,6 @@
 from io import BytesIO, IOBase
 
-import requests
+from requests.adapters import BaseAdapter
 from requests.utils import get_encoding_from_headers, CaseInsensitiveDict
 
 from ._core import Request, send
@@ -9,30 +9,46 @@ from ._core import _StreamingError,_StreamingTimeout
 _IS_PATCHED = False
 
 
-class Session:
-    def __enter__(self):
-        return self
+class PyodideHTTPAdapter(BaseAdapter):
+    """The Base Transport Adapter"""
 
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        pass
+    def __init__(self):
+        super().__init__()
 
-    @staticmethod
-    def request(method, url, **kwargs):
+    def send(
+        self, request, **kwargs
+    ):
+        """Sends PreparedRequest object. Returns Response object.
+        :param request: The :class:`PreparedRequest <PreparedRequest>` being sent.
+        :param stream: (optional) Whether to stream the request content.
+        :param timeout: (optional) How long to wait for the server to send
+            data before giving up, as a float, or a :ref:`(connect timeout,
+            read timeout) <timeouts>` tuple.
+        :type timeout: float or tuple
+        :param verify: (optional) Either a boolean, in which case it controls whether we verify
+            the server's TLS certificate, or a string, in which case it must be a path
+            to a CA bundle to use
+        :param cert: (optional) Any user-provided SSL certificate to be trusted.
+        :param proxies: (optional) The proxies dictionary to apply to the request.
+        """
         stream = kwargs.get('stream', False)
-        request = Request(method, url)
-        request.timeout=kwargs.get('timeout',0)
-        request.params=kwargs.get('params',None)
-        request.headers = kwargs.get('headers', {})
-        if 'json' in kwargs:
-            request.set_json(kwargs['json'])
+        pyodide_request = Request(request.method, request.url)
+        pyodide_request.timeout=kwargs.get('timeout',0)
+        if not pyodide_request.timeout:
+            pyodide_request.timeout=0
+        pyodide_request.params=None # this is done in preparing request now
+        pyodide_request.headers = dict(request.headers)
+        if request.body:
+            pyodide_request.set_body(request.body)
         try:
-            resp = send(request, stream)
+            resp = send(pyodide_request, stream)
         except _StreamingTimeout:
             from requests import ConnectTimeout
-            raise ConnectTimeout(request=request)
+            raise ConnectTimeout(request=pyodide_request)
         except _StreamingError:
             from requests import ConnectionError
-            raise ConnectionError(request=request)
+            raise ConnectionError(request=pyodide_request)
+        import requests
         response = requests.Response()
         # Fallback to None if there's no status_code, for whatever reason.
         response.status_code = getattr(resp, "status_code", None)
@@ -47,8 +63,14 @@ class Session:
             # non-streaming response, make it look like a stream
             response.raw = BytesIO(resp.body)
         response.reason = ''
-        response.url = url
+        response.url = request.url
         return response
+
+
+
+    def close(self):
+        """Cleans up adapter specific items."""
+        pass
 
 
 def patch():
@@ -62,9 +84,14 @@ def patch():
     if _IS_PATCHED:
         return
 
-    class Sessions:
-        Session = Session
+    import requests
+    requests.sessions.Session._old_init=requests.sessions.Session.__init__
+    def new_init(self):
+        self._old_init()
+        self.mount("https://", PyodideHTTPAdapter())
+        self.mount("http://", PyodideHTTPAdapter())        
 
-    requests.api.sessions = Sessions()
+    requests.sessions.Session._old_init=requests.sessions.Session.__init__
+    requests.sessions.Session.__init__=new_init
 
     _IS_PATCHED = True

--- a/pyodide_http/_requests.py
+++ b/pyodide_http/_requests.py
@@ -62,6 +62,15 @@ class PyodideHTTPAdapter(BaseAdapter):
         else:
             # non-streaming response, make it look like a stream
             response.raw = BytesIO(resp.body)
+
+        def new_read(self,amt=None,decode_content=False,cache_content=False):
+            return self.old_read(amt)
+
+        # make the response stream look like a urllib3 stream
+        response.raw.old_read=response.raw.read
+        response.raw.read=new_read.__get__(response.raw,type(response.raw))
+
+
         response.reason = ''
         response.url = request.url
         return response

--- a/pyodide_http/_streaming.py
+++ b/pyodide_http/_streaming.py
@@ -23,10 +23,7 @@ import io
 import json
 import js
 from js import crossOriginIsolated
-try:
-    from pyodide.ffi import to_js
-except ImportError:
-    from pyodide import to_js
+from pyodide.ffi import to_js
 from urllib.request import Request
 SUCCESS_HEADER = -1
 SUCCESS_EOF = -2
@@ -105,7 +102,7 @@ self.addEventListener("message", async function (event) {
             // return the headers first via textencoder
             var headers = [];
             for (const pair of response.headers.entries()) {
-                headers.push([pair[0], pair[0]]);
+                headers.push([pair[0], pair[1]]);
             }
             headerObj = { headers: headers, status: response.status, connectionID };
             const headerText = JSON.stringify(headerObj);
@@ -208,7 +205,7 @@ class _StreamingFetcher:
         body = request.body
         fetch_data = {"headers": headers, "body": body, "method": request.method}
         # start the request off in the worker
-        timeout=int(1000*timeout) if request.timeout>0 else None
+        timeout=int(1000*request.timeout) if request.timeout>0 else None
         shared_buffer = js.SharedArrayBuffer.new(1048576)
         int_buffer = js.Int32Array.new(shared_buffer)
         byte_buffer = js.Uint8Array.new(shared_buffer, 8)

--- a/setup_test_env.sh
+++ b/setup_test_env.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+
+
+# install chrome
+wget -nc https://dl-ssl.google.com/linux/linux_signing_key.pub 
+cat linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/linux_signing_key.gpg  >/dev/null 
+sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/chrome.list' 
+sudo apt update 
+sudo apt install google-chrome-stable 
+
+
+# pyodide build and test
+pip install pytest 
+pip install pyodide-build pytest-pyodide 
+# install chromedriver stuff for selenium to control chrome
+pip install selenium webdriver-manager 
+pip install chromedriver-binary-auto
+# make sure chromedriver is on path
+export PATH=$PATH:`chromedriver-path`
+# get pyodide to tests/pyodide
+# run the tests
+cd tests
+pytest . --dist-dir ./pyodide --rt chrome -v 

--- a/setup_test_env.sh
+++ b/setup_test_env.sh
@@ -19,7 +19,10 @@ pip install selenium webdriver-manager
 pip install chromedriver-binary-auto
 # make sure chromedriver is on path
 export PATH=$PATH:`chromedriver-path`
-# get pyodide to tests/pyodide
+
 # run the tests
 cd tests
+# get pyodide to tests/pyodide
+wget https://github.com/pyodide/pyodide/releases/download/0.21.0/pyodide-build-0.21.0.tar.bz2
+tar xjf pyodide-build-0.21.0.tar.bz2
 pytest . --dist-dir ./pyodide --rt chrome -v 

--- a/tests/test_non_streaming.py
+++ b/tests/test_non_streaming.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+import glob
+
+from pytest_pyodide import run_in_pyodide, spawn_web_server
+from pytest import fixture
+
+@fixture(scope="module")
+def dist_dir(request):
+    # return pyodide dist dir relative to top level of webserver
+    p=Path(request.config.getoption('--dist-dir')).resolve()
+    p=p.relative_to(Path(__file__).parent.parent)
+    return p
+
+@fixture(scope="module")
+def web_server_base():
+    server_folder=Path(__file__).parent.parent
+    with spawn_web_server(server_folder) as server:
+        server_hostname, server_port, _ = server
+        base_url=f"http://{server_hostname}:{server_port}/"
+        yield base_url
+
+def _install_package(selenium,base_url):
+    wheel_folder=Path(__file__).parent.parent / "dist"
+
+    selenium.run_js(
+        f"""
+        await pyodide.loadPackage("micropip");
+        """
+    )
+    selenium.run_async(f'import micropip\nawait micropip.install("requests")')
+
+    for wheel in wheel_folder.glob("*.whl"):
+        url = base_url +"dist/" + str(wheel.name)
+        selenium.run_async(f'await micropip.install("{url}")')
+
+        selenium.run(
+            """
+            import pyodide_http
+            pyodide_http.patch_all()
+            import requests
+            """
+        )
+
+
+def test_install_package(selenium_standalone,web_server_base):
+    _install_package(selenium_standalone,web_server_base)
+
+
+def test_requests_get(selenium_standalone,dist_dir,web_server_base):
+    _install_package(selenium_standalone,web_server_base)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone,base_url):
+        import requests
+        print("get:",base_url)
+        resp=requests.get(f"{base_url}/yt-4.0.4-cp310-cp310-emscripten_3_1_14_wasm32.whl")
+        data=resp.content
+        return len(data)
+
+    assert test_fn(selenium_standalone,f"{web_server_base}{dist_dir}/")==11373926
+
+def test_requests_404(selenium_standalone,dist_dir,web_server_base):
+    _install_package(selenium_standalone,web_server_base)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone,base_url):
+        import requests
+        print("get:",base_url)
+        resp=requests.get(f"{base_url}/surely_this_file_does_not_exist.hopefully.")
+        response=resp.status_code
+        return response
+
+    assert test_fn(selenium_standalone,f"{web_server_base}{dist_dir}/")==404

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,245 @@
+import contextlib
+import http.server
+import multiprocessing
+import queue
+import tempfile
+import shutil
+import sys
+import os
+import socketserver
+
+from pathlib import Path
+import glob
+
+from pytest_pyodide import run_in_pyodide
+from pytest import fixture
+
+@contextlib.contextmanager
+def spawn_web_server_custom(server_folder,custom_headers):
+    tmp_dir = tempfile.mkdtemp()
+    log_path = Path(tmp_dir) / "http-server.log"
+    q = multiprocessing.Queue()
+    p = multiprocessing.Process(target=_run_web_server, args=(q, log_path, server_folder,custom_headers))
+
+    try:
+        p.start()
+        port = q.get(timeout=20)
+        hostname = "127.0.0.1"
+
+        print(
+            f"Spawning webserver at http://{hostname}:{port} "
+            f"(see logs in {log_path})"
+        )
+        yield hostname, port, log_path
+    finally:
+        q.put("TERMINATE")
+        p.join()
+        shutil.rmtree(tmp_dir)
+
+def _run_web_server(q, log_filepath, dist_dir,custom_headers):
+    """Start the HTTP web server
+    Parameters
+    ----------
+    q : Queue
+      communication queue
+    log_path : pathlib.Path
+      path to the file where to store the logs
+    """
+
+    os.chdir(dist_dir)
+
+    log_fh = log_filepath.open("w", buffering=1)
+    sys.stdout = log_fh
+    sys.stderr = log_fh
+
+    class Handler(http.server.SimpleHTTPRequestHandler):
+        def log_message(self, format_, *args):
+            print(
+                "[%s] source: %s:%s - %s"
+                % (self.log_date_time_string(), *self.client_address, format_ % args)
+            )
+
+        def end_headers(self):
+            # Enable Cross-Origin Resource Sharing (CORS)
+            for k,v in custom_headers.items():
+                self.send_header(k,v)
+            self.send_header("Access-Control-Allow-Origin", "*")
+            super().end_headers()
+
+    with socketserver.TCPServer(("", 0), Handler) as httpd:
+        host, port = httpd.server_address
+        print(f"Starting webserver at http://{host}:{port}")
+        httpd.server_name = "test-server"  # type: ignore[attr-defined]
+        httpd.server_port = port  # type: ignore[attr-defined]
+        q.put(port)
+
+        def service_actions():
+            try:
+                if q.get(False) == "TERMINATE":
+                    print("Stopping server...")
+                    sys.exit(0)
+            except queue.Empty:
+                pass
+
+        httpd.service_actions = service_actions  # type: ignore[assignment]
+        httpd.serve_forever()
+
+
+@fixture(scope="module")
+def dist_dir(request):
+    # return pyodide dist dir relative to top level of webserver
+    p=Path(request.config.getoption('--dist-dir')).resolve()
+    p=p.relative_to(Path(__file__).parent.parent)
+    return p
+
+@fixture(scope="module")
+def web_server_non_isolated():
+    server_folder=Path(__file__).parent.parent
+    with spawn_web_server_custom(server_folder,{}) as server:
+        server_hostname, server_port, _ = server
+        base_url=f"http://{server_hostname}:{server_port}/"
+        yield base_url
+
+@fixture(scope="module")
+def web_server_isolated():
+    server_folder=Path(__file__).parent.parent
+    with spawn_web_server_custom(server_folder,{"Cross-Origin-Opener-Policy":"same-origin","Cross-Origin-Embedder-Policy":"require-corp"}) as server:
+        server_hostname, server_port, _ = server
+        base_url=f"http://{server_hostname}:{server_port}/"
+        yield base_url
+
+@fixture(scope="module")
+def big_file_path(dist_dir):
+    test_size=0
+    test_filename=None
+    for f in (Path(__file__).parent.parent / dist_dir).iterdir():
+        if f.is_file():
+            sz=f.stat().st_size
+            if sz>test_size:
+                test_size=sz
+                test_filename=f.name
+    return dist_dir / test_filename,test_size
+
+
+
+def _install_package(selenium,base_url):
+    wheel_folder=Path(__file__).parent.parent / "dist"
+
+    selenium.run_js(
+        f"""
+        await pyodide.loadPackage("micropip");
+        """
+    )
+    selenium.run_async(f'import micropip\nawait micropip.install("requests")')
+
+    for wheel in wheel_folder.glob("*.whl"):
+        url = base_url +"dist/" + str(wheel.name)
+        selenium.run_async(f'await micropip.install("{url}")')
+
+        selenium.run(
+            """
+            import pyodide_http
+            pyodide_http.patch_all()
+            import requests
+            """
+        )
+
+def get_install_package_code(base_url):
+    wheel_folder=Path(__file__).parent.parent / "dist"
+
+    code="""
+import micropip
+await micropip.install("requests")
+"""
+
+    for wheel in wheel_folder.glob("*.whl"):
+        url = base_url +"dist/" + str(wheel.name)
+        code+=f'await micropip.install("{url}")\n'
+
+    code+="""
+import pyodide_http
+pyodide_http.patch_all()
+import requests
+"""
+    return code
+
+
+
+def test_requests_stream_isolated_worker(selenium_standalone,web_server_isolated,big_file_path):
+    test_filename,test_size=big_file_path
+    fetch_url=f"{web_server_isolated}{test_filename}"
+    resp=selenium_standalone.run_webworker(
+        get_install_package_code(web_server_isolated)+
+        f"""
+import requests
+print("get:",'{fetch_url}')
+resp=requests.get('{fetch_url}',stream=True)
+data_len=0
+data_count=0
+while True:
+    this_len=len(resp.raw.read())
+    data_len+=this_len
+    data_count+=1
+    if this_len==0:
+        break
+assert data_count>1
+data_len
+        """)
+
+    assert resp==big_file_path[1] 
+
+def test_requests_stream_non_isolated_worker(selenium_standalone,web_server_non_isolated,big_file_path):
+    test_filename,test_size=big_file_path
+    fetch_url=f"{web_server_non_isolated}{test_filename}"
+    resp=selenium_standalone.run_webworker(
+        get_install_package_code(web_server_non_isolated)+
+        f"""
+import requests
+print("get:",'{fetch_url}')
+resp=requests.get('{fetch_url}',stream=True)
+data_len=0
+data_count=0
+while True:
+    this_len=len(resp.raw.read())
+    data_len+=this_len
+    data_count+=1
+    if this_len==0:
+        break
+assert data_count>1
+data_len
+        """)
+
+    assert resp==big_file_path[1] 
+
+
+
+def test_requests_404_isolated(selenium_standalone,dist_dir,web_server_isolated):
+    _install_package(selenium_standalone,web_server_isolated)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone,base_url):
+        import requests
+        print("get:",base_url)
+        resp=requests.get(f"{base_url}/surely_this_file_does_not_exist.hopefully.")
+        response=resp.status_code
+        return response
+
+    assert test_fn(selenium_standalone,f"{web_server_isolated}{dist_dir}/")==404
+
+def test_install_package_isolated(selenium_standalone,web_server_isolated):
+    _install_package(selenium_standalone,web_server_isolated)
+
+
+def test_requests_stream_isolated_main_thread(selenium_standalone,dist_dir,web_server_isolated,big_file_path):
+    _install_package(selenium_standalone,web_server_isolated)
+    test_filename,test_size=big_file_path
+    @run_in_pyodide
+    def test_fn(selenium_standalone,fetch_url):
+        import requests
+        print("get:",fetch_url)
+        resp=requests.get(fetch_url,stream=True)
+        data=resp.content
+        return len(data)
+
+    assert test_fn(selenium_standalone,f"{web_server_isolated}{test_filename}")==test_size
+

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -301,5 +301,5 @@ assert (data_count>1)
 # check parallel streaming is happening
 assert (data_minimum_non_zero!=None and data_minimum_non_zero[0]<data_len and data_minimum_non_zero[1]<data_len_2)
 data_len
-    """)
+""")
     assert resp == big_file_path[1]


### PR DESCRIPTION
I changed how this patches requests, because the old one was missing out some stuff, like if you called
`requests.Session` to create a session it was bypassed. It also lost quite a lot of the per-session logic of requests. 

I made a transport class instead, and patched that into the session class. This means it is _almost_ using the official method that requests supports to override transports, the only dodgy monkeypatch is that requests has no support for changing the default transport class for all new sessions, so I patch it onto __init__