### PR TITLE
Use to_js function to convert body to correct javascript type

### DIFF
--- a/pyodide_http/_core.py
+++ b/pyodide_http/_core.py
@@ -2,6 +2,7 @@ import json
 from dataclasses import dataclass, field
 from typing import Optional, Dict
 from email.parser import Parser
+from pyodide.ffi import to_js
 
 # need to import streaming here so that the web-worker is setup
 from ._streaming import send_streaming_request
@@ -109,7 +110,7 @@ def send(request: Request, stream: bool = False) -> Response:
     for name, value in request.headers.items():
         xhr.setRequestHeader(name, value)
 
-    xhr.send(request.body)
+    xhr.send(to_js(request.body))
 
     headers = dict(Parser().parsestr(xhr.getAllResponseHeaders()))
 


### PR DESCRIPTION
This PR is a fix for https://github.com/koenvo/pyodide-http/issues/15

When the `request.body` object contains `bytes` instead of `str` type, it would be converted to a `str` type. Converting it into a string results in something like `'b{"query": "data"}'`.

@joemarshall would you mind doing a review?

Still need to add tests for this, but it seems it's not yet possible to capture the request body using `pytest-pyodide`.