### PR TITLE
Add PyPI badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Pyodide-HTTP
 
+[![PyPI Latest Release](https://img.shields.io/pypi/v/pyodide-http.svg)](https://pypi.org/project/pyodide-http/)
+![GHA](https://github.com/pyodide/pytest-pyodide/actions/workflows/main.yml/badge.svg)
+
 Provides patches for widely used http libraries to make them work in Pyodide environments like JupyterLite.
 
 ## Usage


### PR DESCRIPTION
A small improvement to the readme.

It could also be good to add a repo description and tags for discoverability
![image](https://user-images.githubusercontent.com/630936/207545383-d8fca533-7755-4059-81c4-644dda21b498.png)
(upper right corner on the repo page)