### PR TITLE
Fix issue when timeout argument is passed as tuple

### DIFF
--- a/pyodide_http/_requests.py
+++ b/pyodide_http/_requests.py
@@ -32,6 +32,8 @@ class PyodideHTTPAdapter(BaseAdapter):
         stream = kwargs.get("stream", False)
         pyodide_request = Request(request.method, request.url)
         pyodide_request.timeout = kwargs.get("timeout", 0)
+        if type(pyodide_request.timeout) is tuple:
+            pyodide_request.timeout = pyodide_request.timeout[0]
         if not pyodide_request.timeout:
             pyodide_request.timeout = 0
         pyodide_request.params = None  # this is done in preparing request now

--- a/pyodide_http/_requests.py
+++ b/pyodide_http/_requests.py
@@ -33,7 +33,7 @@ class PyodideHTTPAdapter(BaseAdapter):
         pyodide_request = Request(request.method, request.url)
         pyodide_request.timeout = kwargs.get("timeout", 0)
         if type(pyodide_request.timeout) is tuple:
-            pyodide_request.timeout = pyodide_request.timeout[0]
+            pyodide_request.timeout = pyodide_request.timeout[0] + pyodide_request.timeout[1] if 1 < len(pyodide_request.timeout[1]) else 0
         if not pyodide_request.timeout:
             pyodide_request.timeout = 0
         pyodide_request.params = None  # this is done in preparing request now


### PR DESCRIPTION
Extract Connect timeout as first argument of tuple

https://requests.readthedocs.io/en/latest/user/advanced/#timeouts

Fixes:
![image](https://github.com/koenvo/pyodide-http/assets/7430677/56433360-0715-458d-b555-3695627f481c)
