### PR TITLE
core: send: read body if file

### DIFF
--- a/pyodide_http/_core.py
+++ b/pyodide_http/_core.py
@@ -118,7 +118,12 @@ def send(request: Request, stream: bool = False) -> Response:
         if name.lower() not in HEADERS_TO_IGNORE:
             xhr.setRequestHeader(name, value)
 
-    xhr.send(to_js(request.body))
+    body = request.body
+
+    if hasattr(body, 'read'):
+        body = body.read()
+
+    xhr.send(to_js(body))
 
     headers = dict(Parser().parsestr(xhr.getAllResponseHeaders()))
 


### PR DESCRIPTION
If request.body is a file(-like) interface, read the full contents and then send it.

See https://github.com/koenvo/pyodide-http/issues/38