### PR TITLE
[fix] AttributeError: 'HTTPResponse' object has no attribute 'url'

### DIFF
--- a/pyodide_http/_urllib.py
+++ b/pyodide_http/_urllib.py
@@ -50,6 +50,7 @@ def urlopen(url, *args, **kwargs):
     )
 
     response = HTTPResponse(FakeSock(response_data))
+    response.url = url
     response.begin()
     return response
 


### PR DESCRIPTION
Though not directly relevant.. this is also an [issue with cpython](https://github.com/python/cpython/issues/86228), and there is an open [pull request](https://github.com/python/cpython/pull/22738).

Pyodide uses Javascript XHR to perform the network request, and constructs an 'HTTPResponse' object from the XHR response. When doing so, a 'url' attribute should be added.