### PR TITLE
Allow sending cookies on XMLHttpRequest.send()

### DIFF
--- a/pyodide_http/__init__.py
+++ b/pyodide_http/__init__.py
@@ -5,7 +5,42 @@ try:
 except ImportError:
     _SHOULD_PATCH = False
 
+from contextlib import ContextDecorator
+from dataclasses import dataclass
+
+
 __version__ = "0.2.2"
+
+
+@dataclass
+class Options:
+    with_credentials: bool = False
+
+
+_options = Options()
+
+
+def set_with_credentials_option(value: bool):
+    global _options
+    _options.with_credentials = value
+
+
+class option_context(ContextDecorator):
+    def __init__(self, with_credentials=False):
+        self._with_credentials = with_credentials
+        self._default_options = None
+
+    def __enter__(self):
+        global _options
+        self._default_options = _options
+
+        _options = Options()
+        _options.with_credentials = self._with_credentials
+
+    def __exit__(self, *_):
+        if self._default_options is not None:
+            global _options
+            _options = self._default_options
 
 
 def patch_requests(continue_on_import_error: bool = False):

--- a/pyodide_http/__init__.py
+++ b/pyodide_http/__init__.py
@@ -9,7 +9,7 @@ from contextlib import ContextDecorator
 from dataclasses import dataclass
 
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 
 @dataclass

--- a/pyodide_http/_core.py
+++ b/pyodide_http/_core.py
@@ -4,6 +4,8 @@ from typing import Optional, Dict
 from email.parser import Parser
 from pyodide.ffi import to_js
 
+from . import _options
+
 # need to import streaming here so that the web-worker is setup
 from ._streaming import send_streaming_request
 
@@ -123,6 +125,7 @@ def send(request: Request, stream: bool = False) -> Response:
     if hasattr(body, 'read'):
         body = body.read()
 
+    xhr.withCredentials = _options.with_credentials
     xhr.send(to_js(body))
 
     headers = dict(Parser().parsestr(xhr.getAllResponseHeaders()))

--- a/setup_test_env.sh
+++ b/setup_test_env.sh
@@ -4,18 +4,18 @@ set -e
 
 
 # install chrome
-wget -nc https://dl-ssl.google.com/linux/linux_signing_key.pub 
-cat linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/linux_signing_key.gpg  >/dev/null 
-sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/chrome.list' 
-sudo apt update 
-sudo apt install google-chrome-stable 
+wget -nc https://dl-ssl.google.com/linux/linux_signing_key.pub
+cat linux_signing_key.pub | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/linux_signing_key.gpg  >/dev/null
+sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/chrome.list'
+sudo apt update
+sudo apt install google-chrome-stable
 
 
 # pyodide build and test
-pip install pytest 
-pip install pyodide-build pytest-pyodide 
+pip install pytest
+pip install pyodide-build pytest-pyodide
 # install chromedriver stuff for selenium to control chrome
-pip install selenium webdriver-manager 
+pip install selenium webdriver-manager
 pip install chromedriver-binary-auto
 # make sure chromedriver is on path
 export PATH=$PATH:`chromedriver-path`
@@ -23,6 +23,8 @@ export PATH=$PATH:`chromedriver-path`
 # run the tests
 cd tests
 # get pyodide to tests/pyodide
-wget https://github.com/pyodide/pyodide/releases/download/0.21.0/pyodide-build-0.21.0.tar.bz2
-tar xjf pyodide-build-0.21.0.tar.bz2
-pytest . --dist-dir ./pyodide --rt chrome -v 
+wget https://github.com/pyodide/pyodide/releases/download/0.25.1/pyodide-0.25.1.tar.bz2
+tar xjf pyodide-0.25.1.tar.bz2
+cp "$(python3 -c 'import os.path; import pytest_pyodide; print(os.path.dirname(pytest_pyodide.__file__))')/_templates/test.html" pyodide/
+cp "$(python3 -c 'import os.path; import pytest_pyodide; print(os.path.dirname(pytest_pyodide.__file__))')/_templates/webworker_dev.js" pyodide/
+pytest . --dist-dir ./pyodide --rt chrome -v

--- a/tests/pyodide_worker.js
+++ b/tests/pyodide_worker.js
@@ -1,4 +1,4 @@
-importScripts("https://cdn.jsdelivr.net/pyodide/v0.21.3/full/pyodide.js");
+importScripts("https://cdn.jsdelivr.net/pyodide/v0.25.1/full/pyodide.js");
 
 onmessage = async function (e) {
   try {

--- a/tests/test_non_streaming.py
+++ b/tests/test_non_streaming.py
@@ -53,6 +53,37 @@ def test_install_package(selenium_standalone, web_server_base):
     _install_package(selenium_standalone, web_server_base)
 
 
+def test_credentials_context_manager(selenium_standalone, dist_dir, web_server_base):
+    _install_package(selenium_standalone, web_server_base)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone, base_url):
+        import pyodide_http as ph
+
+        assert not ph._options.with_credentials
+
+        with ph.option_context(with_credentials=True):
+            assert ph._options.with_credentials
+
+        assert not ph._options.with_credentials
+
+
+def test_credentials_option(selenium_standalone, dist_dir, web_server_base):
+    _install_package(selenium_standalone, web_server_base)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone, base_url):
+        import pyodide_http as ph
+
+        assert not ph._options.with_credentials
+
+        ph.set_with_credentials_option(True)
+        assert ph._options.with_credentials
+
+        ph.set_with_credentials_option(False)
+        assert not ph._options.with_credentials
+
+
 def test_requests_get(selenium_standalone, dist_dir, web_server_base):
     _install_package(selenium_standalone, web_server_base)
 

--- a/tests/test_non_streaming.py
+++ b/tests/test_non_streaming.py
@@ -1,8 +1,9 @@
 from pathlib import Path
+import os.path
 import glob
 
 from pytest_pyodide import run_in_pyodide, spawn_web_server
-from pytest import fixture
+from pytest import fixture, fail
 
 
 @fixture(scope="module")
@@ -43,6 +44,9 @@ def _install_package(selenium, base_url):
             import requests
             """
         )
+        break
+    else:
+        fail(f"no pre-built *.whl found in {os.path.relpath(wheel_folder)}")
 
 
 def test_install_package(selenium_standalone, web_server_base):
@@ -56,15 +60,52 @@ def test_requests_get(selenium_standalone, dist_dir, web_server_base):
     def test_fn(selenium_standalone, base_url):
         import requests
 
+        import pyodide_http._requests
+        assert pyodide_http._requests._IS_PATCHED
+
+        import pyodide_http as ph
+
         print("get:", base_url)
-        url = f"{base_url}/yt-4.0.4-cp310-cp310-emscripten_3_1_14_wasm32.whl"
-        resp = requests.get(url)
+        url = f"{base_url}/yt-4.1.4-cp311-cp311-emscripten_3_1_46_wasm32.whl"
+
+        # The test web server sets "Access-Control-Allow-Origin: *" which disallows sending credentials.
+        # Credentials are explicitly disabled, although that's the default, to exercise the option code.
+        with ph.option_context(with_credentials=False):
+            resp = requests.get(url)
+
         data = resp.content
         assert resp.request.url == url
 
         return len(data)
 
-    assert test_fn(selenium_standalone, f"{web_server_base}{dist_dir}/") == 11373926
+    assert test_fn(selenium_standalone, f"{web_server_base}{dist_dir}/") == 78336150
+
+
+def test_urllib_get(selenium_standalone, dist_dir, web_server_base):
+    _install_package(selenium_standalone, web_server_base)
+
+    @run_in_pyodide
+    def test_fn(selenium_standalone, base_url):
+        import urllib.request
+
+        import pyodide_http._urllib
+        assert pyodide_http._urllib._IS_PATCHED
+
+        import pyodide_http as ph
+
+        # The test web server sets "Access-Control-Allow-Origin: *" which disallows sending credentials.
+        # Credentials are explicitly disabled, although that's the default, to exercise the option code.
+        ph.set_with_credentials_option(False)
+
+        print("get:", base_url)
+        url = f"{base_url}/yt-4.1.4-cp311-cp311-emscripten_3_1_46_wasm32.whl"
+        with urllib.request.urlopen(url) as resp:
+            data = resp.read()
+            assert resp.url == url
+
+            return len(data)
+
+    assert test_fn(selenium_standalone, f"{web_server_base}{dist_dir}/") == 78336150
 
 
 def test_requests_404(selenium_standalone, dist_dir, web_server_base):
@@ -73,6 +114,9 @@ def test_requests_404(selenium_standalone, dist_dir, web_server_base):
     @run_in_pyodide
     def test_fn(selenium_standalone, base_url):
         import requests
+
+        import pyodide_http._requests
+        assert pyodide_http._requests._IS_PATCHED
 
         print("get:", base_url)
         resp = requests.get(f"{base_url}/surely_this_file_does_not_exist.hopefully.")

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -9,10 +9,11 @@ import os
 import socketserver
 
 from pathlib import Path
+import os.path
 import glob
 
 import pytest_pyodide
-from pytest import fixture
+from pytest import fixture, fail
 from pytest_pyodide import run_in_pyodide
 
 
@@ -160,6 +161,9 @@ def _install_package(selenium, base_url):
             import requests
             """
         )
+        break
+    else:
+        fail(f"no pre-built *.whl found in {os.path.relpath(wheel_folder)}")
 
 
 def get_install_package_code(base_url):


### PR DESCRIPTION
`XMLHttpRequest.send()` does not send any cookies that the browser may have for the requested URL unless `withCredentials = True`. This PR ~enables that flag by default~ allows setting that flag as an option.

This allows doing requests to URLs that depend on cookie-based authentication (e.g. where the user authenticates in one browser tab/window, and the pyodide application is running in another tab/window).

I tested this by overriding the `pyodide_http._core.send()` function in a [Marimo WASM](https://docs.marimo.io/guides/wasm/) notebook, and then doing a `requests.get()` against an URL protected by [Cloudflare Access](https://developers.cloudflare.com/cloudflare-one/identity/authorization-cookie/) (which uses cookies as one of the possible authentication methods). This is the code I used:

```
import js
import pyodide_http
import pyodide_http._core as ph
from pyodide.ffi import to_js
from email.parser import Parser
from pyodide_http._streaming import send_streaming_request

def my_send(request: ph.Request, stream: bool = False) -> ph.Response:
    js.eval("console.log('send() override')")

    if request.params:
        from js import URLSearchParams

        params = URLSearchParams.new()
        for k, v in request.params.items():
            params.append(k, v)
        request.url += "?" + params.toString()

    from js import XMLHttpRequest

    try:
        from js import importScripts  # noqa

        _IN_WORKER = True
    except ImportError:
        _IN_WORKER = False
    # support for streaming workers (in worker )
    if stream:
        if not _IN_WORKER:
            stream = False
            ph.show_streaming_warning()
        else:
            result = send_streaming_request(request)
            if result == False:  # noqa
                stream = False
            else:
                return result

    xhr = XMLHttpRequest.new()
    # set timeout only if pyodide is in a worker, because
    # there is a warning not to set timeout on synchronous main thread
    # XMLHttpRequest https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/timeout
    if _IN_WORKER and request.timeout != 0:
        xhr.timeout = int(request.timeout * 1000)

    if _IN_WORKER:
        xhr.responseType = "arraybuffer"
    else:
        xhr.overrideMimeType("text/plain; charset=ISO-8859-15")

    xhr.open(request.method, request.url, False)
    for name, value in request.headers.items():
        if name.lower() not in ph.HEADERS_TO_IGNORE:
            xhr.setRequestHeader(name, value)

    xhr.withCredentials = True
    xhr.send(to_js(request.body))

    headers = dict(Parser().parsestr(xhr.getAllResponseHeaders()))

    if _IN_WORKER:
        body = xhr.response.to_py().tobytes()
    else:
        body = xhr.response.encode("ISO-8859-15")

    return ph.Response(status_code=xhr.status, headers=headers, body=body)

ph.send = my_send
pyodide_http.patch_all()
```